### PR TITLE
fix(contests): add `page` param

### DIFF
--- a/contests.md
+++ b/contests.md
@@ -8,6 +8,10 @@
     <td><code>GET /contest/list</code></td>
   </tr>
   <tr>
+    <th align="right">参数</th>
+    <td><code>{ page?: number }</code></td>
+  </tr>
+  <tr>
     <th align="right">响应主体</th>
     <td><code>application/json</code> (<code>DataResponse&lt;{ contests: List&lt;Contest&gt; }&gt;</code>)</td>
   </tr>


### PR DESCRIPTION
经测试，查询参数 `page` 参数可以指定查询的起始的页数，按开始时间戳降序，每页默认 20 个比赛。