### PR TITLE
fix: deprecated request header

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@
 ```js
 await fetch("https://www.luogu.com.cn/problem/list?type=P&keyword=模板", {
   headers: [
-    ["x-luogu-type", "content-only"],
+    ["x-lentille-request", "content-only"],
   ],
 });
 ```


### PR DESCRIPTION
题库已切换为新前端，应该使用 `x-lentille-request` 而非 `x-luogu-type`。